### PR TITLE
Enable multiple measurements on the custom metric. No environment var…

### DIFF
--- a/haswell/Makefile
+++ b/haswell/Makefile
@@ -27,8 +27,11 @@ CXX=g++
 endif
 endif
 
-CFLAGS=--std=c++11 -O3 -fPIC -I$(ARM_FORGE_METRIC_PLUGIN_DIR)/include
-LFLAGS=-lpapi
+#PAPI_DIR=/path/to/papi/installation
+PAPI_DIR=/usr
+
+CFLAGS=--std=c++11 -O3 -fPIC -I$(ARM_FORGE_METRIC_PLUGIN_DIR)/include -I$(PAPI_DIR)/include
+LFLAGS=-L$(PAPI_DIR)/lib -lpapi
 DEFAULTCONFIGDIR=~/.allinea/map/metrics
 
 CONFIGDIR := $(shell if [ -z "${ALLINEA_CONFIG_DIR}" ]; then echo "$(DEFAULTCONFIGDIR)"; else echo "${ALLINEA_CONFIG_DIR}/map/metrics";  fi)

--- a/haswell/haswell_memory_bound.xml
+++ b/haswell/haswell_memory_bound.xml
@@ -1,4 +1,5 @@
 <metricdefinitions version="1">
+
     <metric id="haswell.papi.active_cycles">
         <enabled>default_yes</enabled>
         <units>Cycles/s</units>
@@ -29,7 +30,7 @@
             divideBySampleTime="false" />
         <display>
             <displayName>Productive cycles</displayName>
-            <description>Ratio of productive to active cycles over a sample period</description>
+            <description>Fraction of active cycles that are not stalled (productive) over a sample period</description>
             <type>other</type>
             <colour>SpecialLine6</colour>
         </display>
@@ -45,7 +46,39 @@
             divideBySampleTime="false" />
         <display>
             <displayName>Stall cycles</displayName>
-            <description>Ratio of stalled to active cycles over a sample period</description>
+            <description>Fraction of active cycles that are stalled over a sample period</description>
+            <type>other</type>
+            <colour>SpecialLine6</colour>
+        </display>
+    </metric>
+
+    <metric id="haswell.papi.store_buffer_stall_cycles">
+        <enabled>default_yes</enabled>
+        <units></units>
+        <dataType>double</dataType>
+        <domain>time</domain>
+        <source ref="haswell.papi.membound.src"
+            functionName="haswell_membound_store_buffer_stall_cycles"
+            divideBySampleTime="false" />
+        <display>
+            <displayName>Store buffer stall cycles</displayName>
+            <description>Fraction of active cycles that are stalled due to full store buffer over a sample period. Used to calculate memory bound and bandwidth bound stall cycles. When using ARM_MAP_BANDWIDTH_BOUND=1 it is the fraction of stalled cycles.</description>
+            <type>other</type>
+            <colour>SpecialLine6</colour>
+        </display>
+    </metric>
+
+    <metric id="haswell.papi.l1d_pending_stall_cycles">
+        <enabled>default_yes</enabled>
+        <units></units>
+        <dataType>double</dataType>
+        <domain>time</domain>
+        <source ref="haswell.papi.membound.src"
+            functionName="haswell_membound_l1d_pending_stall_cycles"
+            divideBySampleTime="false" />
+        <display>
+            <displayName>L1D pending stall cycles</displayName>
+            <description>Fraction of active cycles that are stalled due to at least one L1D demand load outstanding over a sample period. Used to calculate memory bound stall cycles.</description>
             <type>other</type>
             <colour>SpecialLine6</colour>
         </display>
@@ -61,7 +94,39 @@
             divideBySampleTime="false" />
         <display>
             <displayName>Cycles memory bound</displayName>
-            <description>Fraction of cycles that are stalled waiting on memory</description>
+            <description>Fraction of stalled cycles that are stalled waiting on memory</description>
+            <type>other</type>
+            <colour>SpecialLine6</colour>
+        </display>
+    </metric>
+
+    <metric id="haswell.papi.l1d_pend_miss_fb_full_cycles">
+        <enabled>default_yes</enabled>
+        <units></units>
+        <dataType>double</dataType>
+        <domain>time</domain>
+        <source ref="haswell.papi.membound.src"
+            functionName="haswell_membound_l1d_pend_miss_fb_full_cycles"
+            divideBySampleTime="false" />
+        <display>
+            <displayName>L1D fill buffer unavailable stall cycles</displayName>
+            <description>Fraction of stalled cycles due to L1D fill buffer unavailable over a sample period. Used to calculate bandwidth bound cycles.</description>
+            <type>other</type>
+            <colour>SpecialLine6</colour>
+        </display>
+    </metric>
+
+    <metric id="haswell.papi.offcore_requests_buffer_sq_cycles">
+        <enabled>default_yes</enabled>
+        <units></units>
+        <dataType>double</dataType>
+        <domain>time</domain>
+        <source ref="haswell.papi.membound.src"
+            functionName="haswell_membound_offcore_requests_buffer_sq_cycles"
+            divideBySampleTime="false" />
+        <display>
+            <displayName>Offcore requests buffer full stall cycles</displayName>
+            <description>Fraction of stalled cycles due to offcore requests buffer full over a sample period. Used to calculate bandwidth bound cycles.</description>
             <type>other</type>
             <colour>SpecialLine6</colour>
         </display>
@@ -77,12 +142,13 @@
             divideBySampleTime="false" />
         <display>
             <displayName>Cycles bandwidth bound</displayName>
-            <description>Fraction of cycles that are stalled because of memory bandwidth reasons</description>
+            <description>Fraction of stalled cycles that are stalled because of memory bandwidth reasons over a sample period</description>
             <type>other</type>
             <colour>SpecialLine6</colour>
         </display>
     </metric>
 
+<!--
     <metric id="haswell.papi.latency_bound">
         <enabled>default_yes</enabled>
         <units></units>
@@ -93,7 +159,7 @@
             divideBySampleTime="false" />
         <display>
             <displayName>Cycles latency bound</displayName>
-            <description>Fraction of cycles that are stalled because of memory latency reasons</description>
+            <description>Fraction of stalled cycles that are stalled because of memory latency reasons</description>
             <type>other</type>
             <colour>SpecialLine6</colour>
         </display>
@@ -109,22 +175,29 @@
             divideBySampleTime="false" />
         <display>
             <displayName>Stalled for other reasons</displayName>
-            <description>Fraction of cycles that are stalled for non-memory related reasons</description>
+            <description>Fraction of stalled cycles that are stalled for non-memory related reasons</description>
             <type>other</type>
             <colour>SpecialLine6</colour>
         </display>
     </metric>
+-->
 
     <metricGroup id="Haswell_papi_memory_boundedness">
         <displayName>MemoryBound</displayName>
         <description>Gives a measure of how memory bound an application is. This is only accurate on Intel Haswell (Xeon v3) cores</description>
         <metric ref="haswell.papi.active_cycles"/>
         <metric ref="haswell.papi.productive_cycles"/>
-        <metric ref="haswell.papi.stall_cycles" />
+        <metric ref="haswell.papi.stall_cycles"/>
+	<metric ref="haswell.papi.store_buffer_stall_cycles"/>
+	<metric ref="haswell.papi.l1d_pending_stall_cycles"/>
         <metric ref="haswell.papi.memory_bound" />
+	<metric ref="haswell.papi.l1d_pend_miss_fb_full_cycles"/>
+	<metric ref="haswell.papi.offcore_requests_buffer_sq_cycles"/>
         <metric ref="haswell.papi.bandwidth_bound" />
+<!--
         <metric ref="haswell.papi.latency_bound" />
         <metric ref="haswell.papi.other_stall_reason" />
+-->
     </metricGroup>
 
     <source id="haswell.papi.membound.src">
@@ -132,5 +205,4 @@
     </source>
 
 </metricdefinitions>
-
 

--- a/haswell/haswell_memory_bound.xml
+++ b/haswell/haswell_memory_bound.xml
@@ -148,56 +148,18 @@
         </display>
     </metric>
 
-<!--
-    <metric id="haswell.papi.latency_bound">
-        <enabled>default_yes</enabled>
-        <units></units>
-        <dataType>double</dataType>
-        <domain>time</domain>
-        <source ref="haswell.papi.membound.src"
-            functionName="haswell_membound_latency_bound"
-            divideBySampleTime="false" />
-        <display>
-            <displayName>Cycles latency bound</displayName>
-            <description>Fraction of stalled cycles that are stalled because of memory latency reasons</description>
-            <type>other</type>
-            <colour>SpecialLine6</colour>
-        </display>
-    </metric>
-
-    <metric id="haswell.papi.other_stall_reason">
-        <enabled>default_yes</enabled>
-        <units></units>
-        <dataType>double</dataType>
-        <domain>time</domain>
-        <source ref="haswell.papi.membound.src"
-            functionName="haswell_membound_other_stall_reason"
-            divideBySampleTime="false" />
-        <display>
-            <displayName>Stalled for other reasons</displayName>
-            <description>Fraction of stalled cycles that are stalled for non-memory related reasons</description>
-            <type>other</type>
-            <colour>SpecialLine6</colour>
-        </display>
-    </metric>
--->
-
     <metricGroup id="Haswell_papi_memory_boundedness">
         <displayName>MemoryBound</displayName>
         <description>Gives a measure of how memory bound an application is. This is only accurate on Intel Haswell (Xeon v3) cores</description>
         <metric ref="haswell.papi.active_cycles"/>
         <metric ref="haswell.papi.productive_cycles"/>
         <metric ref="haswell.papi.stall_cycles"/>
-	<metric ref="haswell.papi.store_buffer_stall_cycles"/>
-	<metric ref="haswell.papi.l1d_pending_stall_cycles"/>
+        <metric ref="haswell.papi.store_buffer_stall_cycles"/>
+        <metric ref="haswell.papi.l1d_pending_stall_cycles"/>
         <metric ref="haswell.papi.memory_bound" />
-	<metric ref="haswell.papi.l1d_pend_miss_fb_full_cycles"/>
-	<metric ref="haswell.papi.offcore_requests_buffer_sq_cycles"/>
+        <metric ref="haswell.papi.l1d_pend_miss_fb_full_cycles"/>
+        <metric ref="haswell.papi.offcore_requests_buffer_sq_cycles"/>
         <metric ref="haswell.papi.bandwidth_bound" />
-<!--
-        <metric ref="haswell.papi.latency_bound" />
-        <metric ref="haswell.papi.other_stall_reason" />
--->
     </metricGroup>
 
     <source id="haswell.papi.membound.src">

--- a/haswell/lib_haswell_memory_bound.cpp
+++ b/haswell/lib_haswell_memory_bound.cpp
@@ -30,6 +30,8 @@
 
 static const int ERROR = -1; // Returned by a function when there is an error
 
+static int ARM_MAP_MEMORY_BOUND= 1; // =0 for ARM_MAP_BANDWIDTH_BOUND
+
 ///////////////////////////////////////////////////////////////////////////////
 // The next definitions are user defined. We know the names of the counters
 // that are to be collected, and assign each of these an index into an array of
@@ -39,33 +41,49 @@ static const int ERROR = -1; // Returned by a function when there is an error
 // events; and gEventValues is the array into which the counter values are put
 ///////////////////////////////////////////////////////////////////////////////
 
-// We know the names of the events that we want
-enum EventInds {
+// use namespaces so we can reuse enum's.
+namespace MB { // MEMORY_BOUND
+  // We know the names of the events that we want
+  enum EventInds {
     CLK_UNHALTED_IND=0,
     CYCLE_ACTIVITY_NO_EXECUTE_IND,
     RESOURCE_STALLS_SB_IND,
     CYCLE_ACTIVITY_STALLS_L1D_PENDING_IND,
+    NUM_INDS
+  };
+  constexpr static std::array<const char*, EventInds::NUM_INDS>
+  gEventNames {
+    "CPU_CLK_UNHALTED",
+      "CYCLE_ACTIVITY:CYCLES_NO_EXECUTE",
+      "RESOURCE_STALLS:SB",
+      "CYCLE_ACTIVITY:STALLS_L1D_PENDING"
+      };
+  // We want to store the event codes, but don't necessarily know these (we can
+  // get them from the documentation for a particular hardware set, or let
+  // PAPI return the code for the string name during set up)
+  static std::array<int, EventInds::NUM_INDS> gEventCodes;
+  // Want to also store the event values
+  static std::array<long long, EventInds::NUM_INDS> gEventValues;
+}
+
+namespace BB { // BANDWIDTH_BOUND
+  enum EventInds {
+    CYCLE_ACTIVITY_NO_EXECUTE_IND=0,
+    RESOURCE_STALLS_SB_IND,
     L1D_PEND_MISS_FB_FULL_IND,
     OFFCORE_REQUESTS_BUFFER_SQ_IND,
     NUM_INDS
-};
-
-constexpr static std::array<const char*, EventInds::NUM_INDS> gEventNames {
-    "CPU_CLK_UNHALTED",
+  };
+  constexpr static std::array<const char*, EventInds::NUM_INDS>
+  gEventNames {
     "CYCLE_ACTIVITY:CYCLES_NO_EXECUTE",
-    "RESOURCE_STALLS:SB",
-    "CYCLE_ACTIVITY:STALLS_L1D_PENDING",
-    "L1D_PEND_MISS:FB_FULL",
-    "OFFCORE_REQUESTS_BUFFER:SQ_FULL"
-};
-
-// We want to store the event codes, but don't necessarily know these (we can
-// get them from the documentation for a particular hardware set, or we can let
-// PAPI return the code for the string name during set up)
-static std::array<int, EventInds::NUM_INDS> gEventCodes;
-
-// Want to also store the event values
-static std::array<long long, EventInds::NUM_INDS> gEventValues;
+      "RESOURCE_STALLS:SB",
+      "L1D_PEND_MISS:FB_FULL",
+      "OFFCORE_REQUESTS_BUFFER:SQ_FULL"
+      };
+  static std::array<int, EventInds::NUM_INDS> gEventCodes;
+  static std::array<long long, EventInds::NUM_INDS> gEventValues;
+}
 
 // A global PAPI event set is stored to collect the counter values
 static int gEventSet= PAPI_NULL;
@@ -102,7 +120,12 @@ int haswell_membound_active_cycles(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    *out_value= gEventValues.at(EventInds::CLK_UNHALTED_IND);
+    *out_value= 0;
+    using namespace MB;
+    if (ARM_MAP_MEMORY_BOUND) {
+      *out_value= gEventValues.at(EventInds::CLK_UNHALTED_IND);
+    }
+
     return 0;
 }
 
@@ -112,10 +135,16 @@ int haswell_membound_productive_cycles(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    // The value out here is given as a fraction of active cycles
-    *out_value= static_cast<double>(gEventValues.at(EventInds::CLK_UNHALTED_IND) -
-            gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND)) /
-        gEventValues.at(EventInds::CLK_UNHALTED_IND);
+    *out_value= 0.0;
+    using namespace MB;
+
+    if (ARM_MAP_MEMORY_BOUND) {
+      // The value out here is given as a fraction of active cycles
+      *out_value=
+	static_cast<double>(gEventValues.at(EventInds::CLK_UNHALTED_IND) -
+        gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND)) /
+        static_cast<double>(gEventValues.at(EventInds::CLK_UNHALTED_IND));
+    }
     return 0;
 }
 
@@ -125,17 +154,67 @@ int haswell_membound_stall_cycles(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    // The value out here is given as a fraction of active cycles
-    *out_value= static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND)) /
-        gEventValues.at(EventInds::CLK_UNHALTED_IND);
+    *out_value= 0.0;
+    using namespace MB;
 
+    // The value out here is given as a fraction of active cycles
+    if (ARM_MAP_MEMORY_BOUND) {
+      *out_value=
+	static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND)) /
+        static_cast<double>(gEventValues.at(EventInds::CLK_UNHALTED_IND));
+    }
+    return 0;
+}
+
+int haswell_membound_store_buffer_stall_cycles(metric_id_t metric_id,
+        struct timespec *current_sample_time, double *out_value)
+{
+    // Update the counter values at the current sample period
+    update_values(metric_id, current_sample_time);
+
+    *out_value= 0.0;
+    if (ARM_MAP_MEMORY_BOUND) {
+      // The value out here is given as a fraction of active cycles
+      *out_value=
+	static_cast<double>(MB::gEventValues.at(MB::EventInds::RESOURCE_STALLS_SB_IND)) /
+        static_cast<double>(MB::gEventValues.at(MB::EventInds::CLK_UNHALTED_IND));
+    } else {
+      // The value out here is given as a fraction of stalled cycles
+      *out_value=
+	static_cast<double>(BB::gEventValues.at(BB::EventInds::RESOURCE_STALLS_SB_IND)) /
+        static_cast<double>(BB::gEventValues.at(BB::EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND));
+    }
+    return 0;
+}
+
+int haswell_membound_l1d_pending_stall_cycles(metric_id_t metric_id,
+        struct timespec *current_sample_time, double *out_value)
+{
+    // Update the counter values at the current sample period
+    update_values(metric_id, current_sample_time);
+
+    *out_value= 0.0;
+    using namespace MB;
+
+    // The value out here is given as a fraction of active cycles
+    if (ARM_MAP_MEMORY_BOUND) {
+      *out_value=
+	static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_STALLS_L1D_PENDING_IND)) /
+        static_cast<double>(gEventValues.at(EventInds::CLK_UNHALTED_IND));
+    }
     return 0;
 }
 
 static uint64_t memory_bound_measure()
 {
+  using namespace MB;
+
+  if (ARM_MAP_MEMORY_BOUND) {
     return std::max(gEventValues.at(EventInds::RESOURCE_STALLS_SB_IND),
-            gEventValues.at(EventInds::CYCLE_ACTIVITY_STALLS_L1D_PENDING_IND));
+      gEventValues.at(EventInds::CYCLE_ACTIVITY_STALLS_L1D_PENDING_IND));
+  } else {
+    return 0;
+  }
 }
 
 int haswell_membound_memory_bound(metric_id_t metric_id,
@@ -144,17 +223,63 @@ int haswell_membound_memory_bound(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    // The value out here is given as a fraction of active cycles
-    *out_value= static_cast<double>(memory_bound_measure()) /
-        gEventValues.at(EventInds::CLK_UNHALTED_IND);
+    *out_value= 0.0;
+    using namespace MB;
+
+    if (ARM_MAP_MEMORY_BOUND) {
+      // The value out here is given as a fraction of STALLED cycles
+      *out_value= static_cast<double>(memory_bound_measure()) /
+        static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND));
+    }
+    return 0;
+}
+
+int haswell_membound_l1d_pend_miss_fb_full_cycles(metric_id_t metric_id,
+        struct timespec *current_sample_time, double *out_value)
+{
+    // Update the counter values at the current sample period
+    update_values(metric_id, current_sample_time);
+    *out_value= 0.0;
+    using namespace BB;
+
+    if (!ARM_MAP_MEMORY_BOUND) {
+      // The value out here is given as a fraction of STALLED cycles
+      *out_value=
+	static_cast<double>(gEventValues.at(EventInds::L1D_PEND_MISS_FB_FULL_IND))/
+	static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND));
+    }
+
+    return 0;
+}
+
+int haswell_membound_offcore_requests_buffer_sq_cycles(metric_id_t metric_id,
+        struct timespec *current_sample_time, double *out_value)
+{
+    // Update the counter values at the current sample period
+    update_values(metric_id, current_sample_time);
+    *out_value= 0.0;
+    using namespace BB;
+
+    if (!ARM_MAP_MEMORY_BOUND) {
+      // The value out here is given as a fraction of STALLED cycles
+      *out_value=
+	static_cast<double>(gEventValues.at(EventInds::OFFCORE_REQUESTS_BUFFER_SQ_IND))/
+	static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND));
+    }
+
     return 0;
 }
 
 static uint64_t bandwidth_bound_measure()
 {
+  using namespace BB;
+  if (!ARM_MAP_MEMORY_BOUND) {
     return std::max(gEventValues.at(EventInds::RESOURCE_STALLS_SB_IND),
             gEventValues.at(EventInds::L1D_PEND_MISS_FB_FULL_IND) +
             gEventValues.at(EventInds::OFFCORE_REQUESTS_BUFFER_SQ_IND));
+  } else {
+    return 0;
+  }
 }
 
 int haswell_membound_bandwidth_bound(metric_id_t metric_id,
@@ -162,10 +287,15 @@ int haswell_membound_bandwidth_bound(metric_id_t metric_id,
 {
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
+    *out_value= 0.0;
+    using namespace BB;
 
-    // The value out here is given as a fraction of active cycles
-    *out_value= static_cast<double>(bandwidth_bound_measure()) /
-        gEventValues.at(EventInds::CLK_UNHALTED_IND);
+    if (!ARM_MAP_MEMORY_BOUND) {
+      // The value out here is given as a fraction of STALLED cycles
+      *out_value= static_cast<double>(bandwidth_bound_measure()) /
+        static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND));
+    }
+
     return 0;
 }
 
@@ -175,9 +305,14 @@ int haswell_membound_latency_bound(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    // The value out here is given as a fraction of active cycles
+    *out_value= 0.0;
+    // this metric will have to be derived after combining the sets of metrics
+    // in a data format outside of map
+#if 0
+    // The value out here is given as a fraction of stalled cycles
     *out_value= static_cast<double>(memory_bound_measure() - bandwidth_bound_measure()) /
-        gEventValues.at(EventInds::CLK_UNHALTED_IND);
+        gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND);
+#endif
 
     return 0;
 }
@@ -187,11 +322,16 @@ int haswell_membound_other_stall_reason(metric_id_t metric_id,
 {
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
+    *out_value= 0;
 
+    // this metric will have to be derived after combining the sets of metrics
+    // in a data format outside of map
+#if 0
     // The value out here is given as a fraction of active cycles
     *out_value= static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND) -
             memory_bound_measure()) /
         gEventValues.at(EventInds::CLK_UNHALTED_IND);
+#endif
 
     return 0;
 }
@@ -203,6 +343,36 @@ static unsigned long int haswell_membound_get_thread_id()
     return syscall(__NR_gettid);
 }
 
+/**
+ * Gets in event codes for event names
+ */
+template<int NI>
+int get_event_codes(std::array<int, NI> & eventCodes,
+		    const std::array<const char*, NI> eventNames)
+{
+  // Get the event codes for the string descriptors
+  // Begin by initialising the event codes to some known invalid value
+  eventCodes.fill(0);
+  auto codeIt= eventCodes.begin();
+  // At this point the event codes array should be the same size as the event
+  // names array
+  assert(eventCodes.size() == eventNames.size());
+  for (const auto& name : eventNames) {
+    int eventCode= PAPI_NULL;
+    if (PAPI_event_name_to_code(const_cast<char*>(name), &eventCode)
+	!= PAPI_OK) {
+      //  TODO: Add some actual error handling in here. For the time
+      //  being we just ignore any issue with the counter name
+      printf("PAPI_NOT_OK!\n");
+      codeIt++;
+      continue;
+    }
+    printf("Adding event code %x for name: %s\n",eventCode,name);
+    *codeIt= eventCode;
+    codeIt++;
+  }
+  return 0;
+}
 
 /**
  * Initialises the PAPI library and adds the counters defined at the beginning
@@ -212,6 +382,15 @@ static unsigned long int haswell_membound_get_thread_id()
  */
 int haswell_membound_initialise_papi(plugin_id_t plugin_id)
 {
+    const char* ambb = getenv("ARM_MAP_BANDWIDTH_BOUND");
+    if (ambb == NULL) {
+      printf("Using ARM_MAP_MEMORY_BOUND. Set ARM_MAP_BANDWIDTH_BOUND=1 to measure bandwidth bound cycles.\n");
+      ARM_MAP_MEMORY_BOUND= 1;
+    } else {
+      printf("Using ARM_MAP_BANDWIDTH_BOUND.\n");
+      ARM_MAP_MEMORY_BOUND= 0;
+    }
+
     // Initialise the library and check the initialisation was successful
     int retval = PAPI_library_init(PAPI_VER_CURRENT);
     if (retval != PAPI_VER_CURRENT  &&  retval > 0)
@@ -221,6 +400,7 @@ int haswell_membound_initialise_papi(plugin_id_t plugin_id)
     }
     if (retval < 0)
     {
+        printf("Could not initialise PAPI library. PAPI error: %s", PAPI_strerror(retval));
         allinea_set_plugin_error_messagef(plugin_id, retval, "Could not initialise PAPI library. PAPI error: %s", PAPI_strerror(retval));
         return ERROR;
     }
@@ -257,74 +437,84 @@ int haswell_membound_initialise_papi(plugin_id_t plugin_id)
     }
 
     // Get the event codes for the string descriptors
-    // Begin by initialising the event codes to some known invalid value
-    gEventCodes.fill(0);
-    auto codeIt= gEventCodes.begin();
-    // At this point the event codes array should be the same size as the event
-    // names array
-    assert(gEventCodes.size() == gEventNames.size());
-    for (const auto& name : gEventNames) {
-        int eventCode= PAPI_NULL;
-        if (PAPI_event_name_to_code(const_cast<char*>(name), &eventCode) != PAPI_OK) {
-            //  TODO: Add some actual error handling in here. For the time
-            //  being we just ignore any issue with the counter name
-            codeIt++;
-            continue;
-        }
-        *codeIt= eventCode;
-        codeIt++;
-    }
+    if (ARM_MAP_MEMORY_BOUND)
+      get_event_codes<MB::EventInds::NUM_INDS>
+	(MB::gEventCodes, MB::gEventNames);
+    else
+      get_event_codes<BB::EventInds::NUM_INDS>
+	(BB::gEventCodes, BB::gEventNames);
 
     return 0;
 }
+
+template<int NI>
+int initialize_events(int * eventSetPtr, plugin_id_t plugin_id,
+		      std::array<int, NI> & eventCodes,
+		      const std::array<const char*, NI> eventNames,
+		      std::array<long long, NI> & eventValues)
+{
+  // Create the event sets
+  int retval = PAPI_create_eventset(eventSetPtr);
+  if (retval != PAPI_OK) {
+    allinea_set_plugin_error_messagef(plugin_id, retval, "Could not create event set: %s", PAPI_strerror(retval));
+    return ERROR;
+  }
+
+  // We assume that all of the events have been found at this point
+  retval= PAPI_add_events(*eventSetPtr, eventCodes.data(),
+			  eventCodes.size());
+  if (retval != PAPI_OK) {
+    if (retval > 0) {
+      printf("Error adding events to the event set. Last successful event added \"%s\".\n",
+	     eventNames[retval-1]);
+      
+      allinea_set_plugin_error_messagef(plugin_id, retval,
+					"Error adding events to the event set. Last successful "
+					"event added: \"%s\"\n.",
+					eventNames[retval-1]);
+    } else {
+      allinea_set_plugin_error_messagef(plugin_id, retval, "Error "
+					"adding events to the event set: %s",
+					PAPI_strerror(retval));
+    }
+    return ERROR;
+  }
+
+  // Start the event set
+  retval = PAPI_start(*eventSetPtr);
+  if (retval != PAPI_OK) {
+    allinea_set_plugin_error_messagef(plugin_id, retval, "Could not get PAPI_start: %s", PAPI_strerror(retval));
+    return retval;
+  }
+  // Set the counter values to zero to start with
+  eventValues.fill(0);
+
+  return 0;
+}
+
 
 extern "C" {
     // This function is called before the program starts executing. The function
     // signature must remain unchanged to be picked up by the Arm MAP sampler. This is where initialization of the PAPI library and the
     int allinea_plugin_initialize(plugin_id_t plugin_id, void *unused)
     {
+
         if (haswell_membound_initialise_papi(plugin_id) != 0)
         {
             // allinea_set_plugin_error_message() should have been called by haswell_membound_initialise_papi()
             return ERROR;
         }
 
-        // Create the event sets
-        int retval = PAPI_create_eventset(&gEventSet);
-        if (retval != PAPI_OK)
-        {
-            allinea_set_plugin_error_messagef(plugin_id, retval, "Could not create event set: %s", PAPI_strerror(retval));
-            return ERROR;
-        }
-
-        // We assume that all of the events have been found at this point
-        retval= PAPI_add_events(gEventSet, gEventCodes.data(), gEventCodes.size());
-        if (retval != PAPI_OK) {
-            if (retval > 0){
-                allinea_set_plugin_error_messagef(plugin_id, retval, "Error adding"
-                        " events to the event set. First error detected adding "
-                        "event \"%s\". PAPI error string given as  %s", 
-                        gEventNames[retval-1], PAPI_strerror(retval));
-            }
-            else {
-                allinea_set_plugin_error_messagef(plugin_id, retval, "Error "
-                        "adding events to the event set: %s",
-                        PAPI_strerror(retval));
-            }
-            return ERROR;
-        }
-
-        // Start the event set
-        retval = PAPI_start(gEventSet);
-        if (retval != PAPI_OK)
-        {
-            allinea_set_plugin_error_messagef(plugin_id, retval, "Could not get PAPI_start: %s", PAPI_strerror(retval));
-            return retval;
-        }
-
-        // Set the counter values to zero to start with
-        gEventValues.fill(0);
-
+	if (ARM_MAP_MEMORY_BOUND)
+	  initialize_events<MB::EventInds::NUM_INDS>(&gEventSet, plugin_id,
+						     MB::gEventCodes,
+						     MB::gEventNames,
+						     MB::gEventValues);
+	else
+	  initialize_events<BB::EventInds::NUM_INDS>(&gEventSet, plugin_id,
+						     BB::gEventCodes,
+						     BB::gEventNames,
+						     BB::gEventValues);
         return 0;
     }
 
@@ -334,32 +524,34 @@ extern "C" {
     int allinea_plugin_cleanup(plugin_id_t plugin_id, void *unused)
     {
         // Stop the event set counting
-        int retval= PAPI_stop(gEventSet, gEventValues.data());
-        if (retval != PAPI_OK)
-        {
-            allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_stop: %s", PAPI_strerror(retval));
-            return ERROR;
-        }
-        // Remove all events from the event set
-        retval = PAPI_cleanup_eventset(gEventSet);
-        if (retval != PAPI_OK)
-        {
-            allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_cleanup_eventset: %s", PAPI_strerror(retval));
-            return ERROR;
-        }
+      int retval;
+      if (ARM_MAP_MEMORY_BOUND)
+	retval= PAPI_stop(gEventSet, MB::gEventValues.data());
+      else
+	retval= PAPI_stop(gEventSet, BB::gEventValues.data());
 
-        // Destroy the event set
-        retval = PAPI_destroy_eventset(&gEventSet);
-        if (retval != PAPI_OK)
-        {
-            allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_destroy_eventset: %s", PAPI_strerror(retval));
-            return ERROR;
-        }
+      if (retval != PAPI_OK) {
+	allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_stop: %s", PAPI_strerror(retval));
+	return ERROR;
+      }
+      // Remove all events from the event set
+      retval = PAPI_cleanup_eventset(gEventSet);
+      if (retval != PAPI_OK) {
+	allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_cleanup_eventset: %s", PAPI_strerror(retval));
+	return ERROR;
+      }
 
-        // Reset the event set
-        gEventSet= PAPI_NULL;
+      // Destroy the event set
+      retval = PAPI_destroy_eventset(&gEventSet);
+      if (retval != PAPI_OK) {
+	allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_destroy_eventset: %s", PAPI_strerror(retval));
+	return ERROR;
+      }
 
-        return 0;
+      // Reset the event set
+      gEventSet= PAPI_NULL;
+
+      return 0;
     }
 
 } // extern "C"
@@ -377,11 +569,18 @@ static int update_values(metric_id_t metric_id, const struct timespec* current_s
 
     // Accumulate the values in the counters. The counter values are zeroed
     // before this method, and counters are reset after retrieving the value
-    gEventValues.fill(0);
-    int retval= PAPI_accum(gEventSet, gEventValues.data());
-    if (retval != PAPI_OK){
-        allinea_set_metric_error_messagef(metric_id, retval, "Error updating metric values: %s", PAPI_strerror(retval));
-        return ERROR;
+    int retval;
+    if (ARM_MAP_MEMORY_BOUND) {
+      MB::gEventValues.fill(0);
+      retval= PAPI_accum(gEventSet, MB::gEventValues.data());
+    } else {
+      BB::gEventValues.fill(0);
+      retval= PAPI_accum(gEventSet, BB::gEventValues.data());
+    }
+
+    if (retval != PAPI_OK) {
+      allinea_set_metric_error_messagef(metric_id, retval, "Error updating metric values: %s", PAPI_strerror(retval));
+      return ERROR;
     }
 
     sLastSampleTime= now;

--- a/haswell/lib_haswell_memory_bound.cpp
+++ b/haswell/lib_haswell_memory_bound.cpp
@@ -120,7 +120,6 @@ int haswell_membound_active_cycles(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    *out_value= 0;
     using namespace MB;
     if (ARM_MAP_MEMORY_BOUND) {
       *out_value= gEventValues.at(EventInds::CLK_UNHALTED_IND);
@@ -135,13 +134,12 @@ int haswell_membound_productive_cycles(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    *out_value= 0.0;
     using namespace MB;
 
     if (ARM_MAP_MEMORY_BOUND) {
       // The value out here is given as a fraction of active cycles
       *out_value=
-	static_cast<double>(gEventValues.at(EventInds::CLK_UNHALTED_IND) -
+        static_cast<double>(gEventValues.at(EventInds::CLK_UNHALTED_IND) -
         gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND)) /
         static_cast<double>(gEventValues.at(EventInds::CLK_UNHALTED_IND));
     }
@@ -154,13 +152,12 @@ int haswell_membound_stall_cycles(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    *out_value= 0.0;
     using namespace MB;
 
     // The value out here is given as a fraction of active cycles
     if (ARM_MAP_MEMORY_BOUND) {
       *out_value=
-	static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND)) /
+        static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND)) /
         static_cast<double>(gEventValues.at(EventInds::CLK_UNHALTED_IND));
     }
     return 0;
@@ -172,16 +169,15 @@ int haswell_membound_store_buffer_stall_cycles(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    *out_value= 0.0;
     if (ARM_MAP_MEMORY_BOUND) {
       // The value out here is given as a fraction of active cycles
       *out_value=
-	static_cast<double>(MB::gEventValues.at(MB::EventInds::RESOURCE_STALLS_SB_IND)) /
+        static_cast<double>(MB::gEventValues.at(MB::EventInds::RESOURCE_STALLS_SB_IND)) /
         static_cast<double>(MB::gEventValues.at(MB::EventInds::CLK_UNHALTED_IND));
     } else {
       // The value out here is given as a fraction of stalled cycles
       *out_value=
-	static_cast<double>(BB::gEventValues.at(BB::EventInds::RESOURCE_STALLS_SB_IND)) /
+        static_cast<double>(BB::gEventValues.at(BB::EventInds::RESOURCE_STALLS_SB_IND)) /
         static_cast<double>(BB::gEventValues.at(BB::EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND));
     }
     return 0;
@@ -193,13 +189,12 @@ int haswell_membound_l1d_pending_stall_cycles(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    *out_value= 0.0;
     using namespace MB;
 
     // The value out here is given as a fraction of active cycles
     if (ARM_MAP_MEMORY_BOUND) {
       *out_value=
-	static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_STALLS_L1D_PENDING_IND)) /
+        static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_STALLS_L1D_PENDING_IND)) /
         static_cast<double>(gEventValues.at(EventInds::CLK_UNHALTED_IND));
     }
     return 0;
@@ -223,7 +218,6 @@ int haswell_membound_memory_bound(metric_id_t metric_id,
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
 
-    *out_value= 0.0;
     using namespace MB;
 
     if (ARM_MAP_MEMORY_BOUND) {
@@ -239,14 +233,14 @@ int haswell_membound_l1d_pend_miss_fb_full_cycles(metric_id_t metric_id,
 {
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
-    *out_value= 0.0;
+
     using namespace BB;
 
     if (!ARM_MAP_MEMORY_BOUND) {
       // The value out here is given as a fraction of STALLED cycles
       *out_value=
-	static_cast<double>(gEventValues.at(EventInds::L1D_PEND_MISS_FB_FULL_IND))/
-	static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND));
+        static_cast<double>(gEventValues.at(EventInds::L1D_PEND_MISS_FB_FULL_IND))/
+        static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND));
     }
 
     return 0;
@@ -257,14 +251,14 @@ int haswell_membound_offcore_requests_buffer_sq_cycles(metric_id_t metric_id,
 {
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
-    *out_value= 0.0;
+
     using namespace BB;
 
     if (!ARM_MAP_MEMORY_BOUND) {
       // The value out here is given as a fraction of STALLED cycles
       *out_value=
-	static_cast<double>(gEventValues.at(EventInds::OFFCORE_REQUESTS_BUFFER_SQ_IND))/
-	static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND));
+        static_cast<double>(gEventValues.at(EventInds::OFFCORE_REQUESTS_BUFFER_SQ_IND))/
+        static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND));
     }
 
     return 0;
@@ -287,7 +281,7 @@ int haswell_membound_bandwidth_bound(metric_id_t metric_id,
 {
     // Update the counter values at the current sample period
     update_values(metric_id, current_sample_time);
-    *out_value= 0.0;
+
     using namespace BB;
 
     if (!ARM_MAP_MEMORY_BOUND) {
@@ -299,42 +293,6 @@ int haswell_membound_bandwidth_bound(metric_id_t metric_id,
     return 0;
 }
 
-int haswell_membound_latency_bound(metric_id_t metric_id,
-        struct timespec *current_sample_time, double *out_value)
-{
-    // Update the counter values at the current sample period
-    update_values(metric_id, current_sample_time);
-
-    *out_value= 0.0;
-    // this metric will have to be derived after combining the sets of metrics
-    // in a data format outside of map
-#if 0
-    // The value out here is given as a fraction of stalled cycles
-    *out_value= static_cast<double>(memory_bound_measure() - bandwidth_bound_measure()) /
-        gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND);
-#endif
-
-    return 0;
-}
-
-int haswell_membound_other_stall_reason(metric_id_t metric_id,
-        struct timespec *current_sample_time, uint64_t *out_value)
-{
-    // Update the counter values at the current sample period
-    update_values(metric_id, current_sample_time);
-    *out_value= 0;
-
-    // this metric will have to be derived after combining the sets of metrics
-    // in a data format outside of map
-#if 0
-    // The value out here is given as a fraction of active cycles
-    *out_value= static_cast<double>(gEventValues.at(EventInds::CYCLE_ACTIVITY_NO_EXECUTE_IND) -
-            memory_bound_measure()) /
-        gEventValues.at(EventInds::CLK_UNHALTED_IND);
-#endif
-
-    return 0;
-}
 } // extern "C"
 
 //! Returns the thread id of the calling thread
@@ -348,7 +306,7 @@ static unsigned long int haswell_membound_get_thread_id()
  */
 template<int NI>
 int get_event_codes(std::array<int, NI> & eventCodes,
-		    const std::array<const char*, NI> eventNames)
+                    const std::array<const char*, NI> eventNames)
 {
   // Get the event codes for the string descriptors
   // Begin by initialising the event codes to some known invalid value
@@ -360,7 +318,7 @@ int get_event_codes(std::array<int, NI> & eventCodes,
   for (const auto& name : eventNames) {
     int eventCode= PAPI_NULL;
     if (PAPI_event_name_to_code(const_cast<char*>(name), &eventCode)
-	!= PAPI_OK) {
+        != PAPI_OK) {
       //  TODO: Add some actual error handling in here. For the time
       //  being we just ignore any issue with the counter name
       printf("PAPI_NOT_OK!\n");
@@ -439,19 +397,19 @@ int haswell_membound_initialise_papi(plugin_id_t plugin_id)
     // Get the event codes for the string descriptors
     if (ARM_MAP_MEMORY_BOUND)
       get_event_codes<MB::EventInds::NUM_INDS>
-	(MB::gEventCodes, MB::gEventNames);
+        (MB::gEventCodes, MB::gEventNames);
     else
       get_event_codes<BB::EventInds::NUM_INDS>
-	(BB::gEventCodes, BB::gEventNames);
+        (BB::gEventCodes, BB::gEventNames);
 
     return 0;
 }
 
 template<int NI>
 int initialize_events(int * eventSetPtr, plugin_id_t plugin_id,
-		      std::array<int, NI> & eventCodes,
-		      const std::array<const char*, NI> eventNames,
-		      std::array<long long, NI> & eventValues)
+                      std::array<int, NI> & eventCodes,
+                      const std::array<const char*, NI> eventNames,
+                      std::array<long long, NI> & eventValues)
 {
   // Create the event sets
   int retval = PAPI_create_eventset(eventSetPtr);
@@ -462,20 +420,20 @@ int initialize_events(int * eventSetPtr, plugin_id_t plugin_id,
 
   // We assume that all of the events have been found at this point
   retval= PAPI_add_events(*eventSetPtr, eventCodes.data(),
-			  eventCodes.size());
+                          eventCodes.size());
   if (retval != PAPI_OK) {
     if (retval > 0) {
       printf("Error adding events to the event set. Last successful event added \"%s\".\n",
-	     eventNames[retval-1]);
+             eventNames[retval-1]);
       
       allinea_set_plugin_error_messagef(plugin_id, retval,
-					"Error adding events to the event set. Last successful "
-					"event added: \"%s\"\n.",
-					eventNames[retval-1]);
+                                        "Error adding events to the event set. Last successful "
+                                        "event added: \"%s\"\n.",
+                                        eventNames[retval-1]);
     } else {
       allinea_set_plugin_error_messagef(plugin_id, retval, "Error "
-					"adding events to the event set: %s",
-					PAPI_strerror(retval));
+                                        "adding events to the event set: %s",
+                                        PAPI_strerror(retval));
     }
     return ERROR;
   }
@@ -505,16 +463,16 @@ extern "C" {
             return ERROR;
         }
 
-	if (ARM_MAP_MEMORY_BOUND)
-	  initialize_events<MB::EventInds::NUM_INDS>(&gEventSet, plugin_id,
-						     MB::gEventCodes,
-						     MB::gEventNames,
-						     MB::gEventValues);
-	else
-	  initialize_events<BB::EventInds::NUM_INDS>(&gEventSet, plugin_id,
-						     BB::gEventCodes,
-						     BB::gEventNames,
-						     BB::gEventValues);
+        if (ARM_MAP_MEMORY_BOUND)
+          initialize_events<MB::EventInds::NUM_INDS>(&gEventSet, plugin_id,
+                                                     MB::gEventCodes,
+                                                     MB::gEventNames,
+                                                     MB::gEventValues);
+        else
+          initialize_events<BB::EventInds::NUM_INDS>(&gEventSet, plugin_id,
+                                                     BB::gEventCodes,
+                                                     BB::gEventNames,
+                                                     BB::gEventValues);
         return 0;
     }
 
@@ -526,26 +484,26 @@ extern "C" {
         // Stop the event set counting
       int retval;
       if (ARM_MAP_MEMORY_BOUND)
-	retval= PAPI_stop(gEventSet, MB::gEventValues.data());
+        retval= PAPI_stop(gEventSet, MB::gEventValues.data());
       else
-	retval= PAPI_stop(gEventSet, BB::gEventValues.data());
+        retval= PAPI_stop(gEventSet, BB::gEventValues.data());
 
       if (retval != PAPI_OK) {
-	allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_stop: %s", PAPI_strerror(retval));
-	return ERROR;
+        allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_stop: %s", PAPI_strerror(retval));
+        return ERROR;
       }
       // Remove all events from the event set
       retval = PAPI_cleanup_eventset(gEventSet);
       if (retval != PAPI_OK) {
-	allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_cleanup_eventset: %s", PAPI_strerror(retval));
-	return ERROR;
+        allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_cleanup_eventset: %s", PAPI_strerror(retval));
+        return ERROR;
       }
 
       // Destroy the event set
       retval = PAPI_destroy_eventset(&gEventSet);
       if (retval != PAPI_OK) {
-	allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_destroy_eventset: %s", PAPI_strerror(retval));
-	return ERROR;
+        allinea_set_plugin_error_messagef(plugin_id, retval, "Error in PAPI_destroy_eventset: %s", PAPI_strerror(retval));
+        return ERROR;
       }
 
       // Reset the event set

--- a/haswell/merge.sh
+++ b/haswell/merge.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+output=merged.json
+
+file1="stalls_1.json"
+file2="stalls_2.json"
+
+# include the info object from stalls_1.json
+jq '{ info,
+      samples: {
+        metrics : .samples.metrics|with_entries(select(.key|
+                contains("haswell.papi.active_cycles")
+                or contains("haswell.papi.productive_cycles")
+                or contains("haswell.papi.stall_cycles")
+                or contains("haswell.papi.store_buffer_stall_cycles")
+                or contains("haswell.papi.l1d_pending_stall_cycles")
+                or contains("haswell.papi.memory_bound")
+                                                ))}}' $file1 > tmp1
+
+# include the info object from stalls_2.json
+jq '{ samples: {
+        metrics : .samples.metrics|with_entries(select(.key|
+                contains("haswell.papi.l1d_pend_miss_fb_full_cycles")
+                or contains("haswell.papi.offcore_requests_buffer_sq_cycles")
+                or contains("haswell.papi.bandwidth_bound")
+                                                ))}}' $file2 > tmp2
+
+# merge the files
+jq -n 'reduce inputs as $i ({}; . * $i)' tmp1 tmp2 > $output
+
+# clean up
+rm tmp1 tmp2


### PR DESCRIPTION
…iables

set enables ARM_MAP_MEMORY_BOUND which counts the first set of counters to
get stall cycles and memory bound stall cycles. Setting ARM_MAP_BANDWIDTH_BOUND
measures complementary set of counters to quantify stalls as bandwidth or
latency bound.

Squash multi_measurement commits into one.

Work on enabling two sets of measurements based on an environment variable.

Finish up first implementation that enables both sets of measurements.

cleanup

Add metrics for the raw counts of all of the components that make up
the memory boundedness measurements. Remove the metrics (by commenting them
out) that can only be derived by combining results from both measurements.

add script for merging json files choosing the right stall metrics from the right files

Use static casting on each element in expressions that divide
hardware counters. Only casting the result was failing to capture accurate
percentages.

Add storage buffer counter output when using ARM_MAP_BANDWIDTH_BOUND=1. Make
a note in the xml that when using ARM_MAP_BANDWIDTH_BOUND it is the percentage
of stalled cycles, not the percentage of active cycles.

take out machine specific PAPI path

default papi dir to /usr